### PR TITLE
release 3.2.0: retry PostgreSQL pool and migrations with diehard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 3.2.0 - 2026-04-21
+
+### Added
+
+- Retry logic via `diehard` when initializing the PostgreSQL pool and running migrations, so the components tolerate the database being briefly unavailable during container startup. Uses exponential backoff (1s → capped at 15s) with up to 3 retries.
+
 ## 3.1.0 - 2026-04-19
 
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/postgresql "3.1.0"
+(defproject net.clojars.macielti/postgresql "3.2.0"
 
   :description "PostgreSQL Component"
 
@@ -17,7 +17,8 @@
                  [com.github.igrishaev/pg2-migration "0.1.48"]
                  [org.clojure/tools.logging "1.3.1"]
                  [integrant "1.0.1"]
-                 [prismatic/schema "1.4.1"]]
+                 [prismatic/schema "1.4.1"]
+                 [diehard "0.12.0"]]
 
   :resource-paths ["resources"]
 

--- a/src/postgresql/component.clj
+++ b/src/postgresql/component.clj
@@ -1,5 +1,6 @@
 (ns postgresql.component
   (:require [clojure.tools.logging :as log]
+            [diehard.core :as dh]
             [integrant.core :as ig]
             [pg.core])
   (:import (org.pg Pool)))
@@ -10,7 +11,12 @@
   [_ {:keys [components]}]
   (log/info :starting ::postgresql)
   (let [postgresql-config (-> components :config :postgresql)
-        pool (pg.core/pool postgresql-config)]
+        pool (dh/with-retry {:max-retries 3
+                             :backoff-ms  [1000 15000]
+                             :retry-on    Exception
+                             :on-retry    (fn [_ _]
+                                            (log/warn :retrying-postgresql-pool))}
+               (pg.core/pool postgresql-config))]
     pool))
 
 (defmethod ig/halt-key! ::postgresql

--- a/src/postgresql/migrations.clj
+++ b/src/postgresql/migrations.clj
@@ -1,5 +1,6 @@
 (ns postgresql.migrations
   (:require [clojure.tools.logging :as log]
+            [diehard.core :as dh]
             [integrant.core :as ig]
             [pg.migration.core :as migrations]))
 
@@ -9,7 +10,12 @@
   (let [postgresql-config (-> components :config :postgresql)
         migrations-config (-> components :config :postgresql-migrations)
         configuration (merge postgresql-config migrations-config)]
-    (migrations/migrate-all configuration)))
+    (dh/with-retry {:max-retries 3
+                    :backoff-ms  [1000 15000]
+                    :retry-on    Exception
+                    :on-retry    (fn [_ _]
+                                   (log/warn :retrying-postgresql-migrations))}
+      (migrations/migrate-all configuration))))
 
 (defmethod ig/halt-key! ::postgresql-migrations
   [_ _]


### PR DESCRIPTION
## Summary
- Wrap PostgreSQL pool initialization and migration execution with `diehard` retry logic
- Exponential backoff starting at 1s, capped at 15s, with a max of 3 retries
- Improves resilience against transient connection failures on startup

## Test plan
- [x] `lein test` passes locally
- [x] Service starts successfully against a healthy PostgreSQL instance
- [x] Simulate transient PostgreSQL unavailability on startup and confirm retries occur before succeeding
- [x] Confirm pool/migration failure after exceeding max retries surfaces a clear error